### PR TITLE
fix(libssh2): CVE-2026-7598

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libssh2 (1.11.1-1deepin2) unstable; urgency=medium
+
+  * Fix CVE-2026-7598: integer overflow in userauth_password
+    (upstream commit 256d04b60d80bf1190e96b0ad1e91b2174d744b1)
+
+ -- deepin-ci-robot <packages@deepin.org>  Thu, 04 Jun 2026 09:00:00 +0800
+
 libssh2 (1.11.1-1deepin1) unstable; urgency=medium
 
   * revert t64.

--- a/debian/patches/CVE-2026-7598.patch
+++ b/debian/patches/CVE-2026-7598.patch
@@ -1,0 +1,38 @@
+Index: libssh2/src/userauth.c
+===================================================================
+--- libssh2.orig/src/userauth.c
++++ libssh2/src/userauth.c
+@@ -84,6 +84,12 @@ static char *userauth_list(LIBSSH2_SESSI
+ 
+         s = session->userauth_list_data =
+             LIBSSH2_ALLOC(session, session->userauth_list_data_len);
++        if(username_len > UINT32_MAX - 27) {
++            _libssh2_error(session, LIBSSH2_ERROR_PROTO,
++                           "username_len out of bounds");
++            return NULL;
++        }
++
+         if(!session->userauth_list_data) {
+             _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                            "Unable to allocate memory for userauth_list");
+@@ -316,6 +322,11 @@ userauth_password(LIBSSH2_SESSION *sessi
+            struct */
+         s = session->userauth_pswd_data =
+             LIBSSH2_ALLOC(session, session->userauth_pswd_data_len);
++        if(username_len > UINT32_MAX - 40) {
++            return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
++                                  "username_len out of bounds");
++        }
++
+         if(!session->userauth_pswd_data) {
+             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                   "Unable to allocate memory for "
+@@ -447,7 +458,7 @@ password_response:
+                         }
+ 
+                         /* basic data_len + newpw_len(4) */
+-                        if(username_len + password_len + 44 <= UINT_MAX) {
++                        if(username_len <= UINT32_MAX - password_len - 44) {
+                             session->userauth_pswd_data_len =
+                                 username_len + password_len + 44;
+                             s = session->userauth_pswd_data =

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,3 +6,4 @@
 #CVE-2023-48795.patch
 #maxpathlen.patch
 #openssh-9.8.patch
+CVE-2026-7598.patch


### PR DESCRIPTION
Fix integer overflow in userauth_password.

Upstream: https://github.com/libssh2/libssh2/commit/256d04b60d80bf1190e96b0ad1e91b2174d744b1

Co-Authored-By: hudeng <hudeng@deepin.org>

Fix-Approach: patch
Generated-By: deepseek-v4-flash